### PR TITLE
Implement cross-platform alert polyfill

### DIFF
--- a/app/(tabs)/alerts.tsx
+++ b/app/(tabs)/alerts.tsx
@@ -8,7 +8,6 @@ import { observer } from "@legendapp/state/react";
 import React, { useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     FlatList,
     SafeAreaView,
     StyleSheet,
@@ -16,6 +15,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 // Type pour les alertes
 interface AlertData {

--- a/app/auth/confirm.tsx
+++ b/app/auth/confirm.tsx
@@ -4,12 +4,12 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     StyleSheet,
     Text,
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 export default function AuthConfirm() {
   const router = useRouter();

--- a/app/auth/reset-password.tsx
+++ b/app/auth/reset-password.tsx
@@ -4,7 +4,6 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     KeyboardAvoidingView,
     Platform,
     StyleSheet,
@@ -13,6 +12,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 export default function ResetPassword() {
   const router = useRouter();

--- a/components/AddSeniorForm.tsx
+++ b/components/AddSeniorForm.tsx
@@ -2,7 +2,6 @@ import { addSenior, createFamilyRelation, useMyCompanionAuth } from "@/utils/Sup
 import React, { useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     ScrollView,
     StyleSheet,
     Switch,
@@ -11,6 +10,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 interface AddSeniorFormProps {
   onSuccess?: (seniorId: string) => void;

--- a/components/CallHistoryModal.tsx
+++ b/components/CallHistoryModal.tsx
@@ -3,7 +3,6 @@ import { fr } from 'date-fns/locale';
 import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Modal,
   SafeAreaView,
@@ -11,6 +10,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import Alert from '@/utils/Alert';
 import { getSeniorCalls } from '../utils/supabase/services/call-service';
 import { Call, Senior } from '../utils/supabase/types';
 import { ThemedText } from './ThemedText';

--- a/components/CodeCard.tsx
+++ b/components/CodeCard.tsx
@@ -7,11 +7,11 @@ import {
   Animated,
   Share,
   Platform,
-  Alert,
   ActivityIndicator,
 } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import { Ionicons } from "@expo/vector-icons";
+import Alert from "@/utils/Alert";
 
 interface CodeCardProps {
   code: string | null;

--- a/components/EditSeniorForm.tsx
+++ b/components/EditSeniorForm.tsx
@@ -8,7 +8,6 @@ import {
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     ScrollView,
     StyleSheet,
     Text,
@@ -16,6 +15,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 interface EditSeniorFormProps {
   seniorId: string;

--- a/components/FamilySharingScreen.tsx
+++ b/components/FamilySharingScreen.tsx
@@ -10,7 +10,6 @@ import {
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     FlatList,
     SafeAreaView,
     ScrollView,
@@ -19,6 +18,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import CodeCard from "./CodeCard";
 import CodeInput from "./CodeInput";
 import { Ionicons } from "@expo/vector-icons";

--- a/components/JoinFamilyScreen.tsx
+++ b/components/JoinFamilyScreen.tsx
@@ -2,13 +2,13 @@ import { joinFamilyWithCode } from "@/utils/SupaLegend";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useState } from "react";
 import {
-  Alert,
   SafeAreaView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import CodeInput from "./CodeInput";
 
 interface JoinFamilyScreenProps {

--- a/components/ProfileEdit.tsx
+++ b/components/ProfileEdit.tsx
@@ -11,7 +11,6 @@ import { Picker } from "@react-native-picker/picker";
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     ScrollView,
     StyleSheet,
     Switch,
@@ -20,6 +19,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 interface ProfileEditProps {
   onClose?: () => void;

--- a/components/SeniorDetailScreen.tsx
+++ b/components/SeniorDetailScreen.tsx
@@ -2,7 +2,6 @@ import { deleteSenior, getSeniorStats } from "@/utils/SupaLegend";
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     RefreshControl,
     SafeAreaView,
     ScrollView,
@@ -11,6 +10,7 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import SeniorDetailsModal from "./SeniorDetailsModal";
 
 interface SeniorDetailProps {

--- a/components/SeniorsListScreen.tsx
+++ b/components/SeniorsListScreen.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Modal,
   SafeAreaView,
@@ -11,6 +10,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 
 import AddSeniorForm from "@/components/AddSeniorForm";
 import EditSeniorForm from "@/components/EditSeniorForm";

--- a/components/UserProfile.tsx
+++ b/components/UserProfile.tsx
@@ -1,7 +1,6 @@
 import { getUserStats, signOut, useMyCompanionAuth } from "@/utils/SupaLegend";
 import React, { useEffect, useState } from "react";
 import {
-    Alert,
     Platform,
     StyleSheet,
     Text,
@@ -10,6 +9,7 @@ import {
     ScrollView,
     Animated,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 

--- a/components/__tests__/AddSeniorForm.test.tsx
+++ b/components/__tests__/AddSeniorForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Alert } from 'react-native';
+import Alert from '@/utils/Alert';
 import AddSeniorForm from '../AddSeniorForm';
 
 jest.mock('@/utils/SupaLegend', () => ({

--- a/components/__tests__/UserProfile.test.tsx
+++ b/components/__tests__/UserProfile.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { Alert, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import Alert from '@/utils/Alert';
 import UserProfile from '../UserProfile';
 import { getUserStats, signOut, useMyCompanionAuth } from '@/utils/SupaLegend';
 

--- a/components/admin/AdminSeniorsList.tsx
+++ b/components/admin/AdminSeniorsList.tsx
@@ -11,7 +11,8 @@ import * as FileSystem from 'expo-file-system';
 import { router } from 'expo-router';
 import * as Sharing from 'expo-sharing';
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, StyleSheet, TextInput, TouchableOpacity, View, SafeAreaView } from 'react-native';
+import { FlatList, StyleSheet, TextInput, TouchableOpacity, View, SafeAreaView } from 'react-native';
+import Alert from '@/utils/Alert';
 
 interface SeniorItemProps {
   senior: Senior;

--- a/components/admin/AdminUsersList.tsx
+++ b/components/admin/AdminUsersList.tsx
@@ -16,7 +16,8 @@ import { MyCompanionUser, UserType } from '@/utils/supabase/types';
 import { useSelector } from '@legendapp/state/react';
 import { Picker } from '@react-native-picker/picker';
 import React, { useEffect, useState } from 'react';
-import { Alert, FlatList, Modal, StyleSheet, TextInput, TouchableOpacity, View, SafeAreaView } from 'react-native';
+import { FlatList, Modal, StyleSheet, TextInput, TouchableOpacity, View, SafeAreaView } from 'react-native';
+import Alert from '@/utils/Alert';
 
 interface UserItemProps {
   user: MyCompanionUser;

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,7 +2,6 @@ import { signInWithEmail } from "@/utils/SupaLegend";
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     Keyboard,
     KeyboardAvoidingView,
     Platform,
@@ -15,6 +14,7 @@ import {
     TouchableWithoutFeedback,
     View,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import Animated, {
     FadeIn,
     FadeInDown,

--- a/components/auth/SignUpForm.tsx
+++ b/components/auth/SignUpForm.tsx
@@ -3,7 +3,6 @@ import { Picker } from "@react-native-picker/picker";
 import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
-    Alert,
     Platform,
     ScrollView,
     StyleSheet,
@@ -14,6 +13,7 @@ import {
     KeyboardAvoidingView,
     Dimensions,
 } from "react-native";
+import Alert from "@/utils/Alert";
 import Animated, {
     FadeInDown,
     FadeInUp,

--- a/components/auth/__tests__/LoginForm.test.tsx
+++ b/components/auth/__tests__/LoginForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Alert } from 'react-native';
+import Alert from '@/utils/Alert';
 import LoginForm from '../LoginForm';
 // Mock auth module
 jest.mock('@/utils/SupaLegend', () => ({

--- a/components/auth/__tests__/SignUpForm.test.tsx
+++ b/components/auth/__tests__/SignUpForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Alert } from 'react-native';
+import Alert from '@/utils/Alert';
 import SignUpForm from '../SignUpForm';
 
 jest.mock('@/utils/SupaLegend', () => ({

--- a/utils/Alert.ts
+++ b/utils/Alert.ts
@@ -1,0 +1,195 @@
+import { Platform, Alert as RNAlert } from 'react-native';
+
+// Types mirroring the React Native Alert API
+export interface AlertButton {
+  text: string;
+  onPress?: () => void;
+  style?: 'default' | 'cancel' | 'destructive';
+}
+
+export interface AlertOptions {
+  cancelable?: boolean;
+  onDismiss?: () => void;
+}
+
+class Alert {
+  /**
+   * Cross-platform implementation of Alert.alert.
+   * On native platforms we simply proxy to React Native's Alert.
+   * On web, we fallback to window.alert / window.confirm for up to two buttons
+   * and render a custom modal for three or more buttons.
+   */
+  public static alert(
+    title: string = '',
+    message?: string,
+    buttons: AlertButton[] = [{ text: 'OK' }],
+    options: AlertOptions = {}
+  ) {
+    // Mobile & desktop native platforms → use RN Alert directly
+    if (Platform.OS !== 'web') {
+      RNAlert.alert(title, message, buttons, options as any);
+      return;
+    }
+
+    // Web implementation
+    const mergedButtons = buttons.length ? buttons : [{ text: 'OK' }];
+
+    // 1 button → window.alert
+    if (mergedButtons.length === 1) {
+      window.alert([title, message].filter(Boolean).join('\n\n'));
+      mergedButtons[0].onPress?.();
+      options.onDismiss?.();
+      return;
+    }
+
+    // 2 buttons → window.confirm (first button considered "cancel", second "ok")
+    if (mergedButtons.length === 2) {
+      const confirmResult = window.confirm([title, message].filter(Boolean).join('\n\n'));
+      const chosenButton = confirmResult ? mergedButtons[1] : mergedButtons[0];
+      chosenButton.onPress?.();
+      options.onDismiss?.();
+      return;
+    }
+
+    // 3+ buttons → custom modal
+    renderCustomModal(title, message, mergedButtons, options);
+  }
+}
+
+export default Alert;
+
+/* -------------------------------------------------------------------------- */
+/*                                Web Modal                                  */
+/* -------------------------------------------------------------------------- */
+
+function renderCustomModal(
+  title: string,
+  message: string | undefined,
+  buttons: AlertButton[],
+  options: AlertOptions
+) {
+  // Create overlay
+  const overlay = document.createElement('div');
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.width = '100vw';
+  overlay.style.height = '100vh';
+  overlay.style.background = 'rgba(0,0,0,0.4)';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+  overlay.style.zIndex = '10000';
+  overlay.style.animation = 'alertfadein 0.15s ease';
+
+  if (options.cancelable) {
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        cleanup();
+        options.onDismiss?.();
+      }
+    });
+  }
+
+  // Modal container
+  const modal = document.createElement('div');
+  modal.style.background = '#ffffff';
+  modal.style.borderRadius = '12px';
+  modal.style.minWidth = '280px';
+  modal.style.maxWidth = '90vw';
+  modal.style.padding = '20px';
+  modal.style.boxShadow = '0 4px 16px rgba(0,0,0,0.25)';
+  modal.style.display = 'flex';
+  modal.style.flexDirection = 'column';
+  modal.style.gap = '16px';
+  modal.style.animation = 'alertscalein 0.2s ease';
+
+  const titleEl = document.createElement('h2');
+  titleEl.textContent = title;
+  titleEl.style.margin = '0';
+  titleEl.style.fontSize = '18px';
+  titleEl.style.fontWeight = '600';
+  titleEl.style.color = '#000';
+  modal.appendChild(titleEl);
+
+  if (message) {
+    const msgEl = document.createElement('p');
+    msgEl.textContent = message;
+    msgEl.style.margin = '0';
+    msgEl.style.fontSize = '14px';
+    msgEl.style.color = '#333';
+    modal.appendChild(msgEl);
+  }
+
+  // Buttons container
+  const btnContainer = document.createElement('div');
+  btnContainer.style.display = 'flex';
+  btnContainer.style.flexDirection = 'column';
+  btnContainer.style.gap = '8px';
+
+  buttons.forEach((btn) => {
+    const btnEl = document.createElement('button');
+    btnEl.textContent = btn.text;
+    btnEl.style.padding = '10px';
+    btnEl.style.fontSize = '14px';
+    btnEl.style.borderRadius = '8px';
+    btnEl.style.border = 'none';
+    btnEl.style.cursor = 'pointer';
+    btnEl.style.fontWeight = '600';
+
+    // Style variants
+    switch (btn.style) {
+      case 'cancel':
+        btnEl.style.background = '#E5E5EA';
+        btnEl.style.color = '#000';
+        break;
+      case 'destructive':
+        btnEl.style.background = '#FF3B30';
+        btnEl.style.color = '#fff';
+        break;
+      default:
+        btnEl.style.background = '#007AFF';
+        btnEl.style.color = '#fff';
+        break;
+    }
+
+    btnEl.addEventListener('click', () => {
+      btn.onPress?.();
+      cleanup();
+      options.onDismiss?.();
+    });
+
+    btnContainer.appendChild(btnEl);
+  });
+
+  modal.appendChild(btnContainer);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  function cleanup() {
+    if (overlay.parentElement) {
+      document.body.removeChild(overlay);
+    }
+  }
+
+  injectStyles();
+}
+
+function injectStyles() {
+  const styleId = 'alert-polyfill-styles';
+  if (document.getElementById(styleId)) return;
+
+  const style = document.createElement('style');
+  style.id = styleId;
+  style.textContent = `
+    @keyframes alertfadein {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    @keyframes alertscalein {
+      from { transform: scale(0.9); opacity: 0; }
+      to { transform: scale(1); opacity: 1; }
+    }
+  `;
+  document.head.appendChild(style);
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a cross-platform `Alert.alert` polyfill to enable its use on web.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
React Native's `Alert.alert` is not supported on web and causes runtime errors. This polyfill provides a consistent API, using native `Alert` on mobile and a custom web implementation (leveraging `window.alert`/`confirm` or a custom HTML/CSS modal for multiple buttons) to ensure `Alert.alert` functionality across all platforms.

---
<a href="https://cursor.com/background-agent?bcId=bc-9324d4b7-36af-4cbc-9b23-d7c9f10ecccf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9324d4b7-36af-4cbc-9b23-d7c9f10ecccf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>